### PR TITLE
Fix GPT detection failure with long disk names

### DIFF
--- a/WhyNotWin11.au3
+++ b/WhyNotWin11.au3
@@ -144,7 +144,7 @@ Func Main()
 		GUICtrlSetData($hCheck[4][2], _GetCPUInfo(3) & " MHz")
 	EndIf
 
-	RunWait("powershell -Command Get-Partition -DriveLetter C | Get-Disk | Out-File -FilePath " & $hFile, "", @SW_HIDE)
+	RunWait("powershell -Command Get-Partition -DriveLetter C | Get-Disk | Select-Object -Property PartitionStyle | Out-File -FilePath " & $hFile, "", @SW_HIDE)
 	Select
 		Case StringInStr(FileRead($hFile), "Error")
 			GUICtrlSetData($hCheck[6][0], "?")


### PR DESCRIPTION
When the disk name is long (in my case "SAMSUNG SSD SM841N 2.5 7mm 128GB" plus a whole serial number in the next column) and the terminal emulator is narrow, Powershell might not display the PartitionStyle column, causing the GPT check to fail despite the drive being GPT partitioned. This patch fixes that issue by selecting only the PartitionStyle column.