### PR TITLE
add multi-processor support

### DIFF
--- a/includes/_WMIC.au3
+++ b/includes/_WMIC.au3
@@ -26,7 +26,7 @@ Func _GetCPUInfo($iFlag = 0)
 			Local $CPUs
 			$Col_Items = $Obj_WMIService.ExecQuery('Select * from Win32_ComputerSystem')
 			For $Obj_Item In $Col_Items
-				$CPUs = $Obj_Item.NumberOfProcessors
+				$sCPUs = $Obj_Item.NumberOfProcessors
 			Next
 			$sCores *= $CPUs
 			$sThreads *= $CPUs

--- a/includes/_WMIC.au3
+++ b/includes/_WMIC.au3
@@ -22,6 +22,14 @@ Func _GetCPUInfo($iFlag = 0)
 				$sSpeed = $Obj_Item.MaxClockSpeed
 				$sArch = $Obj_Item.AddressWidth
 			Next
+			
+			Local $CPUs
+			$Col_Items = $Obj_WMIService.ExecQuery('Select * from Win32_ComputerSystem')
+			For $Obj_Item In $Col_Items
+				$CPUs = $Obj_Item.NumberOfProcessors
+			Next
+			$sCores *= $CPUs
+			$sThreads *= $CPUs
 		Else
 			Return 0
 		EndIf


### PR DESCRIPTION
Update _GetCPUInfo() to report correct numbers of cores/threads even in case of multi-processor system.