### PR TITLE
delete checksum file if empty

### DIFF
--- a/.github/workflows/wnw11.yml
+++ b/.github/workflows/wnw11.yml
@@ -31,6 +31,7 @@ jobs:
         run: |
           Start-Process "${env:ProgramFiles(x86)}\AutoIt3\AutoIt3.exe" "`"${env:ProgramFiles(x86)}\AutoIt3\SciTE\AutoIt3Wrapper\AutoIt3Wrapper.au3`" /NoStatus /prod /in WhyNotWin11.au3" -NoNewWindow -Wait
           sha256sum -b WhyNotWin*.exe > checksums.sha256
+          get-childItem "checksums.sha256" | where {$_.length -eq 0} | remove-Item
           7z a WhyNotWin11.zip WhyNotWin11*.exe checksums.sha256
       - uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
This is to address issue where the build fails, but CI doesn't because the .sha256 file exists (although empty)

I've found it online, tested and seems to work, but marking as draft, so maybe some powershell expert will come and help with better solution. Thanks.