### PR TITLE
Au3Check  - fix - Local $hJob "already declared"

### DIFF
--- a/WhyNotWin11.au3
+++ b/WhyNotWin11.au3
@@ -399,12 +399,13 @@ Func Main()
 	GUICtrlSetTip(-1, "LTT")
 	GUICtrlSetCursor(-1, 0)
 
+	Local $hJob
 	If @LogonDomain <> @ComputerName Then
-		Local $hJob = GUICtrlCreateLabel("", 34, 310, 32, 32)
+		$hJob = GUICtrlCreateLabel("", 34, 310, 32, 32)
 		GUICtrlSetTip(-1, "I'm For Hire")
 		GUICtrlSetCursor(-1, 0)
 	Else
-		Local $hJob = GUICtrlCreateDummy()
+		$hJob = GUICtrlCreateDummy()
 	EndIf
 
 	Local $hToggle = GUICtrlCreateLabel("", 34, 518, 32, 32)


### PR DESCRIPTION
Local $hJob was declared twice in the same scope/function .
Au3Check fires "already declared". 
This PR fix this issue.