### PR TITLE
Fixing strange Static usage > Const

### DIFF
--- a/WhyNotWin11.au3
+++ b/WhyNotWin11.au3
@@ -339,9 +339,8 @@ EndFunc   ;==>ExtractFiles
 
 Func Main()
 
-	Local Static $iMUI = @MUILang
-	Local Static $aFonts[4]
-	$aFonts = _GetTranslationFonts($iMUI)
+	Local Const $iMUI = @MUILang
+	Local Const $aFonts = _GetTranslationFonts($iMUI)
 
 	Local Enum $FontSmall, $FontMedium, $FontLarge, $FontExtraLarge
 


### PR DESCRIPTION
I do not understand why somebody use Static in this case, IMHO it should be declared as Const .