### PR TITLE
Remove Linux easter egg

### DIFF
--- a/WhyNotWin11.au3
+++ b/WhyNotWin11.au3
@@ -968,17 +968,9 @@ EndFunc   ;==>OutputResults
 ; ===============================================================================================================================
 Func _SetBannerText($hBannerText, $hBanner)
 
-	Local $bLinux = False
 	Local $hModule = _WinAPI_GetModuleHandle(@SystemDir & "\ntdll.dll")
 
-	If _WinAPI_GetProcAddress($hModule, "wine_get_host_version") Then $bLinux = True
-
 	Select
-		Case $bLinux
-			GUICtrlSetData($hBannerText, "i3 BEST WM")
-			Return "https://archlinux.org/"
-			GUICtrlSetCursor($hBannerText, 0)
-			GUICtrlSetCursor($hBanner, 0)
 		Case @LogonDomain <> @ComputerName
 			GUICtrlSetData($hBannerText, "I'M FOR HIRE")
 			Return "https://fcofix.org/rcmaehl/wiki/I'M-FOR-HIRE"


### PR DESCRIPTION
It was fun to add, but wnw11 stopped running on wine around time when new disk detection method was added so I see no sense in it. I think I removed all related code.

![image](https://user-images.githubusercontent.com/45581170/135359052-b4a45840-d39d-47c2-81f4-468861e17f86.png)
