### PR TITLE
Update SupportedProcessorsIntel.txt

### DIFF
--- a/includes/SupportedProcessorsIntel.txt
+++ b/includes/SupportedProcessorsIntel.txt
@@ -482,6 +482,7 @@ Xeon(R) Platinum 8160T
 Xeon(R) Platinum 8164
 Xeon(R) Platinum 8168
 Xeon(R) Platinum 8170
+Xeon(R) Platinum 8171M
 Xeon(R) Platinum 8176
 Xeon(R) Platinum 8176F
 Xeon(R) Platinum 8180
@@ -492,6 +493,7 @@ Xeon(R) Platinum 8260L
 Xeon(R) Platinum 8260Y
 Xeon(R) Platinum 8268
 Xeon(R) Platinum 8270
+Xeon(R) Platinum 8272CL
 Xeon(R) Platinum 8276
 Xeon(R) Platinum 8276L
 Xeon(R) Platinum 8280


### PR DESCRIPTION
**Adding 2 extra Intel Xeon Pentium CPUs (8171M and 8272CL).**

These where added to the official Windows 11 supported Intel processors website at 11/10/2021 onwards.

**Source:**
https://docs.microsoft.com/en-us/windows-hardware/design/minimum/supported/windows-11-supported-intel-processors

**Noticed it by looking at the comparison with highlighted changes between latest archived website captures:**
https://web.archive.org/web/diff/20211108193634/20211114161255/https://docs.microsoft.com/en-us/windows-hardware/design/minimum/supported/windows-11-supported-intel-processors