### PR TITLE
Update SupportedProcessorsAMD.txt

### DIFF
--- a/includes/SupportedProcessorsAMD.txt
+++ b/includes/SupportedProcessorsAMD.txt
@@ -1,4 +1,4 @@
-2.4.2.1
+2.4.2.2
 3015e
 3020e
 Athlon 3000G
@@ -167,6 +167,10 @@ Ryzen 9 5950X
 Ryzen 9 5980HS
 Ryzen 9 5980HX
 Ryzen 9 PRO 3900
+Ryzen Embedded V2000 V2516
+Ryzen Embedded V2000 V2546
+Ryzen Embedded V2000 V2718
+Ryzen Embedded V2000 V2748
 Ryzen Threadripper 2920X
 Ryzen Threadripper 2950X
 Ryzen Threadripper 2970WX


### PR DESCRIPTION
Adding 4 Ryzen Embedded V2000 CPUs.

Source:
https://docs.microsoft.com/en-us/windows-hardware/design/minimum/supported/windows-11-supported-amd-processors

Link to quickly and easily notice the newly added additional 4 AMD CPUs:
https://web.archive.org/web/diff/20211206184613/20211102202403/https://docs.microsoft.com/en-us/windows-hardware/design/minimum/supported/windows-11-supported-amd-processors