### PR TITLE
Update Actions to v3

### DIFF
--- a/.github/workflows/wnw11.yml
+++ b/.github/workflows/wnw11.yml
@@ -6,9 +6,9 @@ jobs:
   build:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Cache tools
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache
         with:
           path: |


### PR DESCRIPTION
Update GitHub Workflow Actions of "checkout" and "cache" from v2 to currently the newest v3.