### PR TITLE
Update SupportedProcessorsAMD.txt

### DIFF
--- a/includes/SupportedProcessorsAMD.txt
+++ b/includes/SupportedProcessorsAMD.txt
@@ -13,6 +13,12 @@ Athlon Silver 3050C
 Athlon Silver 3050e
 Athlon Silver 3050GE
 Athlon Silver 3050U
+Athlon Gold PRO 3125GE
+Athlon Gold PRO 3150G
+Athlon Gold PRO 3150GE
+Athlon PRO 300GE
+Athlon PRO 300U
+Athlon PRO 3045B
 EPYC 7252
 EPYC 7262
 EPYC 7272
@@ -69,6 +75,7 @@ Ryzen 3 3350U
 Ryzen 3 4300G
 Ryzen 3 4300GE
 Ryzen 3 4300U
+Ryzen 3 5300GE
 Ryzen 3 5300U
 Ryzen 3 5400U
 Ryzen 3 PRO 3200G
@@ -85,6 +92,8 @@ Ryzen 5 3600
 Ryzen 5 2500X
 Ryzen 5 2600E
 Ryzen 5 2600X
+Ryzen 5 3350G
+Ryzen 5 3350GE
 Ryzen 5 3400G
 Ryzen 5 3400GE
 Ryzen 5 3450U
@@ -99,6 +108,7 @@ Ryzen 5 4500U
 Ryzen 5 4600G
 Ryzen 5 4600GE
 Ryzen 5 4600H
+Ryzen 5 4600HS
 Ryzen 5 4600U
 Ryzen 5 5300G
 Ryzen 5 5300GE
@@ -109,8 +119,12 @@ Ryzen 5 5600H
 Ryzen 5 5600HS
 Ryzen 5 5600U
 Ryzen 5 5600X
+Ryzen 5 6600H
+Ryzen 5 6600U
 Ryzen 5 PRO 2600
 Ryzen 5 PRO 3600
+Ryzen 5 PRO 3350G
+Ryzen 5 PRO 3350GE
 Ryzen 5 PRO 3400G
 Ryzen 5 PRO 3400GE
 Ryzen 5 PRO 3500U
@@ -119,6 +133,8 @@ Ryzen 5 PRO 4650GE
 Ryzen 5 PRO 4650U
 Ryzen 5 PRO 5650G
 Ryzen 5 PRO 5650GE
+Ryzen 5 PRO 5650HS
+Ryzen 5 PRO 5650HX
 Ryzen 5 PRO 5650U
 Ryzen 5 PRO 5750G
 Ryzen 5 PRO 5750GE
@@ -146,12 +162,18 @@ Ryzen 7 5800H
 Ryzen 7 5800HS
 Ryzen 7 5800U
 Ryzen 7 5800X
+Ryzen 7 6800H
+Ryzen 7 6800U
+Ryzen 7 6810U
 Ryzen 7 PRO 2700
+Ryzen 7 PRO 3700
 Ryzen 7 PRO 2700X
 Ryzen 7 PRO 3700U
 Ryzen 7 PRO 4750G
 Ryzen 7 PRO 4750GE
 Ryzen 7 PRO 4750U
+Ryzen 7 PRO 5850HS
+Ryzen 7 PRO 5850HX
 Ryzen 7 PRO 5850U
 Ryzen 9 5900
 Ryzen 9 3900
@@ -166,11 +188,13 @@ Ryzen 9 5900X
 Ryzen 9 5950X
 Ryzen 9 5980HS
 Ryzen 9 5980HX
+Ryzen 9 6900HX
+Ryzen 9 6980HX
 Ryzen 9 PRO 3900
-Ryzen Embedded V2000 Series V2748
-Ryzen Embedded V2000 Series V2546
-Ryzen Embedded V2000 Series V2718
-Ryzen Embedded V2000 Series V2516
+Ryzen Embedded V2516
+Ryzen Embedded V2546
+Ryzen Embedded V2718
+Ryzen Embedded V2748
 Ryzen Threadripper 2920X
 Ryzen Threadripper 2950X
 Ryzen Threadripper 2970WX


### PR DESCRIPTION
Kept the original order and naming as in the latest source website where the article date is 12th May 2022.
Only change I made to the latest list was to exclude identical duplicates of 3 CPU's.

Source: https://docs.microsoft.com/en-us/windows-hardware/design/minimum/supported/windows-11-supported-amd-processors