### PR TITLE
Add Celeron N5095 to SupportedProcessorsIntel.txt

### DIFF
--- a/includes/SupportedProcessorsIntel.txt
+++ b/includes/SupportedProcessorsIntel.txt
@@ -53,6 +53,7 @@ Celeron(R) N4100
 Celeron(R) N4120
 Celeron(R) N4500
 Celeron(R) N4505
+Celeron(R) N5095
 Celeron(R) N5100
 Celeron(R) N5105
 Celeron(R) N6210


### PR DESCRIPTION
Adds Celeron(R) N5095 to the supported CPUs list

Please describe your feature/changes on this pull:
Add Celeron N5095 to the supported Intel CPUs. It was discussed in this thread (https://github.com/rcmaehl/WhyNotWin11/issues/654) but looks like the change was lost since that commit.

> if this pull request **not** a localization related, please fill and check on this below


- [X] I had read the [contributing guidelines](CONTRIBUTING.md)
- [X] I ensured that my code compiles, if applicable
- [X] I ensured that my feature works properly, if applicable
