### PR TITLE
Fix incorrect OS version check condition

### DIFF
--- a/WhyNotWin11.au3
+++ b/WhyNotWin11.au3
@@ -549,7 +549,7 @@ Func Main(ByRef $aResults, ByRef $aExtended, ByRef $aSkips, ByRef $aOutput, $bFU
 	_GDIPlus_Startup()
 
 	; Disable Scaling
-	If @OSVersion = 'WIN_10' Or 'WIN_11' Then DllCall(@SystemDir & "\User32.dll", "bool", "SetProcessDpiAwarenessContext", "HWND", "DPI_AWARENESS_CONTEXT" - 1)
+	If @OSVersion = 'WIN_10' Or @OSVersion = 'WIN_11' Then DllCall(@SystemDir & "\User32.dll", "bool", "SetProcessDpiAwarenessContext", "HWND", "DPI_AWARENESS_CONTEXT" - 1)
 
 	Local $bComplete = False
 


### PR DESCRIPTION
The condition 'WIN_11' was always evaluated as True (non-empty string) because it was not compared to `@OSVersion`.